### PR TITLE
Add GH-AW chapter and workflow playbook; update TOC, indexes, and blog post

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ This book is **self-maintaining** through automated workflows. When you contribu
 4. Publishes changes to the web
 5. Announces updates via blog posts
 
+For maintainers and agents, see the [Agentic Workflow Playbook](WORKFLOW_PLAYBOOK.md) for the research → plan → assign loop and required artifacts per update.
+
 ## Ways to Contribute
 
 ### 1. Suggest Content (Recommended)

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -8,7 +8,7 @@ This repository implements a **living, self-maintaining book** about agentic wor
 
 ### 📚 Book Content (1199+ lines)
 
-**4 Comprehensive Chapters:**
+**5 Comprehensive Chapters:**
 
 1. **Introduction to Agentic Workflows** (2,982 characters)
    - Defines agentic workflows and key concepts
@@ -34,6 +34,11 @@ This repository implements a **living, self-maintaining book** about agentic wor
    - Creating custom tools with examples
    - Skill development and composition
    - Import and registry patterns
+
+5. **GitHub Agentic Workflows (GH-AW)** (new chapter)
+   - GH-AW workflow structure and compilation model
+   - Imports, tools, and safe outputs
+   - ResearchPlanAssign for continuous book updates
 
 ### 🌐 GitHub Pages Setup
 
@@ -78,6 +83,7 @@ This repository implements a **living, self-maintaining book** about agentic wor
 - `README.md`: Project overview, features, and quick start
 - `CONTRIBUTING.md`: Comprehensive contribution guide (5,355 characters)
 - `SETUP.md`: Detailed setup and troubleshooting guide
+- `WORKFLOW_PLAYBOOK.md`: GH-AW maintenance loop for the book
 - `PROJECT_SUMMARY.md`: This document
 
 ### 🎫 Issue Templates
@@ -161,7 +167,8 @@ agentbook/
 │   │   ├── 01-introduction.md      # Chapter 1
 │   │   ├── 02-orchestration.md     # Chapter 2
 │   │   ├── 03-scaffolding.md       # Chapter 3
-│   │   └── 04-skills-tools.md      # Chapter 4
+│   │   ├── 04-skills-tools.md      # Chapter 4
+│   │   └── 05-gh-agentic-workflows.md # Chapter 5
 │   ├── README.md                    # Book introduction
 │   └── index.md                     # Book homepage
 ├── blog/
@@ -176,6 +183,7 @@ agentbook/
 ├── CONTRIBUTING.md                  # Contribution guide
 ├── index.md                         # Site homepage
 ├── PROJECT_SUMMARY.md              # This file
+├── WORKFLOW_PLAYBOOK.md            # GH-AW maintenance playbook
 ├── README.md                        # Project README
 └── SETUP.md                         # Setup instructions
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Building the infrastructure and frameworks that enable agents to operate effecti
 ### [Skills and Tools Management](book/chapters/04-skills-tools.md)
 How to create, import, and compose agent capabilities for maximum effectiveness.
 
+### [GitHub Agentic Workflows (GH-AW)](book/chapters/05-gh-agentic-workflows.md)
+How GH-AW turns markdown into secure, composable repository automation.
+
 ## 🚀 How It Works
 
 1. **Community Input**: Open an issue with a suggestion

--- a/WORKFLOW_PLAYBOOK.md
+++ b/WORKFLOW_PLAYBOOK.md
@@ -1,0 +1,89 @@
+# Agentic Workflow Playbook for Agentbook
+
+This playbook translates GitHub Agentic Workflows (GH-AW) guidance into a practical, repeatable process for maintaining this book. Use it to keep the repository aligned with the latest tools, libraries, and ideas in agentic workflows.
+
+## Goals
+
+- Discover new agentic workflow practices and tooling.
+- Debate changes in public issues before implementation.
+- Assign clear responsibilities to agents.
+- Keep book chapters, table of contents, and blog posts in sync.
+
+## The Research → Plan → Assign Loop
+
+### 1) Research (Scheduled or Manual)
+
+**Trigger:** scheduled workflow or `workflow_dispatch`.
+
+**Agent tasks:**
+
+- Scan the ecosystem for new libraries, scaffolds, or workflow patterns.
+- Capture citations, links, and a short summary.
+- Create a GitHub issue with a structured proposal.
+
+**Suggested issue structure:**
+
+- **Title:** `[Proposal] <tool or pattern name>`
+- **Summary:** why the proposal matters
+- **Evidence:** links, benchmarks, examples
+- **Book impact:** which chapter(s) to update
+- **Suggested next step:** accept, revise, or reject
+
+### 2) Plan (Human-Gated)
+
+**Trigger:** maintainer review of the proposal issue.
+
+**Decision logic:**
+
+- **Accept** → label `accepted` and request an agent update.
+- **Revise** → label `needs-revision` and ask for clarifications.
+- **Reject** → label `rejected` with rationale.
+
+### 3) Assign & Implement
+
+**Trigger:** accepted proposal.
+
+**Agent tasks:**
+
+- Update the relevant chapter(s) and the table of contents.
+- Ensure the book homepage and index pages reflect new content.
+- Add a blog post announcing the update.
+- Let GitHub Actions rebuild the PDF and publish Pages.
+
+## Required Artifacts per Update
+
+- ✅ Chapter update or new chapter markdown
+- ✅ `book/chapters/00-toc.md` and `book/index.md` refreshed
+- ✅ Root `index.md` updated (homepage links)
+- ✅ New `_posts/<date>-<slug>.md` blog entry
+
+## Recommended GH-AW Workflow Components
+
+Use shared components and imports to keep workflows consistent:
+
+```markdown
+---
+imports:
+  - shared/common-tools.md
+  - shared/safe-outputs.md
+  - shared/issue-templates.md
+---
+```
+
+### Tooling baseline
+
+- `edit` for file updates
+- `github` toolset for issues/PRs
+- `web-search` and `web-fetch` for research
+- Optional `cache-memory` for trend tracking
+
+## Example Consensus Checklist
+
+- [ ] Proposal issue created
+- [ ] At least one maintainer comment
+- [ ] Outcome label applied (`accepted` / `needs-revision` / `rejected`)
+- [ ] Agent assigned for implementation
+
+## How This Supports the Book
+
+This playbook ensures the book stays aligned with the evolving GH-AW ecosystem while keeping humans in control of what gets published. It also provides a repeatable, auditable process for future agents to follow.

--- a/_posts/2026-02-05-gh-aw-chapter.md
+++ b/_posts/2026-02-05-gh-aw-chapter.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: "New Chapter: GitHub Agentic Workflows"
+date: 2026-02-05
+---
+
+We just added a new chapter on **GitHub Agentic Workflows (GH-AW)**, the emerging approach that turns markdown instructions into secure, composable GitHub Actions powered by AI agents.
+
+## What’s New in the Book
+
+The new chapter explains:
+
+- How GH-AW workflows are structured (frontmatter + markdown)
+- Why compilation to `.lock.yml` matters for reproducibility
+- How tools, safe inputs, and safe outputs keep automation secure
+- How imports and shared components enable reusable workflow building blocks
+- The ResearchPlanAssign pattern for continuous, human-guided improvement
+
+## Operational Playbook
+
+Alongside the chapter, we added an **Agentic Workflow Playbook** for this repo that documents a research → plan → assign loop. It makes it easier to:
+
+1. Discover new libraries or scaffolds
+2. Debate proposals in issues
+3. Assign agents to implement accepted updates
+4. Keep the book and blog synchronized
+
+## Read the Chapter
+
+Start with **Chapter 5: GitHub Agentic Workflows (GH-AW)** and follow the playbook to see how the book maintains itself in practice.
+
+---
+
+*This update follows our self-maintaining workflow: research, consensus, implementation, and publication.*

--- a/book/README.md
+++ b/book/README.md
@@ -17,6 +17,7 @@ This book is a living document that explores the fascinating world of agentic wo
 2. [Agent Orchestration](chapters/02-orchestration.md)
 3. [Agentic Scaffolding](chapters/03-scaffolding.md)
 4. [Skills and Tools Management](chapters/04-skills-tools.md)
+5. [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
 
 ## Contributing
 

--- a/book/chapters/00-toc.md
+++ b/book/chapters/00-toc.md
@@ -35,6 +35,13 @@ title: Table of Contents
    - Skill development
    - Best practices
 
+5. **[GitHub Agentic Workflows (GH-AW)](05-gh-agentic-workflows.html)**
+   - What GH-AW is and why it matters
+   - Workflow structure and compilation
+   - Tools, safe inputs, safe outputs
+   - Imports and shared components
+   - ResearchPlanAssign for self-maintaining books
+
 ---
 
 [← Back to Book Home](../index.html)

--- a/book/chapters/05-gh-agentic-workflows.md
+++ b/book/chapters/05-gh-agentic-workflows.md
@@ -1,0 +1,143 @@
+# Chapter 5: GitHub Agentic Workflows (GH-AW)
+
+## Why GH-AW Matters
+
+GitHub Agentic Workflows (GH-AW) turns natural language into automated repository agents that run inside GitHub Actions. Instead of writing large YAML pipelines by hand, you write markdown instructions that an AI agent executes with guardrails. The result is a workflow you can read like documentation but run like automation.
+
+At a glance, GH-AW provides:
+
+- **Natural language workflows**: Markdown instructions drive the agent’s behavior.
+- **Compile-time structure**: Markdown is compiled into GitHub Actions workflows for reproducibility.
+- **Security boundaries**: Permissions, tools, and safe outputs define what the agent can and cannot do.
+- **Composable automation**: Imports and shared components enable reuse across repositories.
+
+## Core Workflow Structure
+
+A GH-AW workflow is a markdown file with frontmatter and instructions:
+
+```markdown
+---
+on:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+tools:
+  edit:
+  github:
+    toolsets: [issues]
+engine: copilot
+---
+
+# Triage this issue
+Read issue #${{ github.event.issue.number }} and summarize it.
+```
+
+**Key parts:**
+
+1. **Frontmatter**
+   - `on`: GitHub Actions triggers (issues, schedules, dispatch, etc.)
+   - `permissions`: least-privilege access to GitHub APIs
+   - `tools`: the capabilities your agent can invoke (edit, bash, web, github)
+   - `engine`: AI model/provider (Copilot, Claude Code, Codex)
+
+2. **Markdown instructions**
+   - Natural language steps for the agent
+   - Context variables from the event payload (issue number, PR, repo)
+
+## How GH-AW Runs
+
+GH-AW compiles markdown workflows into `.lock.yml` GitHub Actions workflows. The compiled file is what GitHub actually executes, but the markdown remains the authoritative source. This gives you readable automation with predictable execution.
+
+Key behaviors to remember:
+
+- **Frontmatter edits require recompile**.
+- **Markdown instruction updates can often be edited directly** (the runtime loads the markdown body).
+- **Shared components** can be stored as markdown files without `on:`; they are imported, not compiled.
+
+## Tools, Safe Inputs, and Safe Outputs
+
+GH-AW workflows are designed for safety by default. Agents run with minimal access and must declare tools explicitly.
+
+### Tools
+
+Tools are capabilities the agent can use:
+
+- **edit**: modify files in the workspace
+- **bash**: run shell commands (by default only safe commands)
+- **web-fetch / web-search**: fetch or search web content
+- **github**: operate on issues, PRs, discussions, projects
+- **playwright**: browser automation for UI checks
+
+### Safe Outputs
+
+Write actions (creating issues, comments, commits) can be routed through safe outputs to sanitize what the agent writes. This keeps the core job read-only and limits accidental changes.
+
+### Safe Inputs
+
+You can define safe inputs to structure what the agent receives. This is a good place to validate schema-like data for tools or commands.
+
+## Imports and Reusable Components
+
+GH-AW supports imports in two ways:
+
+- **Frontmatter imports**
+
+```yaml
+imports:
+  - shared/common-tools.md
+  - shared/research-library.md
+```
+
+- **Markdown directive**
+
+```markdown
+{{#import shared/common-tools.md}}
+```
+
+Imports let you create a library of reusable workflow fragments (shared tools, standard prompts, or organization-wide policies). Files without `on:` become *components* that can be imported without being compiled into Actions.
+
+## ResearchPlanAssign: A Pattern for Self-Maintaining Books
+
+GH-AW documents a **ResearchPlanAssign** strategy: a scaffolded loop that keeps humans in control while delegating research and execution to agents.
+
+**Phase 1: Research**
+- A scheduled agent scans the repo or ecosystem (new libraries, frameworks, scaffolds).
+- It produces a report in an issue or discussion.
+
+**Phase 2: Plan**
+- Maintainers review the report and decide whether to proceed.
+- A planning agent drafts the implementation steps if approved.
+
+**Phase 3: Assign & Implement**
+- Agents are assigned to implement the approved changes.
+- Updates are validated, committed, and published.
+
+This pattern maps well to this book: use scheduled research to discover new agentic tooling, post a proposal issue, build consensus, then update the chapters and blog.
+
+## Applying GH-AW to This Repository
+
+Here’s how GH-AW can drive the book’s maintenance:
+
+1. **Research (scheduled)**
+   - Use web-search tooling to scan for new agentic workflow libraries.
+   - Produce a structured report in a GitHub issue.
+2. **Consensus (issues/discussions)**
+   - Collect votes or comments to accept/reject the proposal.
+   - Label outcomes (`accepted`, `needs-revision`, `rejected`).
+3. **Implementation (assigned agent)**
+   - Update or add chapters.
+   - Refresh the table of contents and homepage.
+   - Add a blog post summarizing the update.
+4. **Publish (automation)**
+   - Pages and PDF rebuild automatically after merge.
+
+This approach keeps the book aligned with the latest GH-AW practices while maintaining a transparent, auditable workflow.
+
+## Key Takeaways
+
+- GH-AW turns markdown instructions into reproducible GitHub Actions workflows.
+- Frontmatter defines triggers, permissions, tools, and models.
+- Imports enable composable, reusable workflow building blocks.
+- Safe inputs/outputs and least-privilege permissions reduce risk.
+- ResearchPlanAssign provides a practical loop for continuous, agent-powered improvement.

--- a/book/index.md
+++ b/book/index.md
@@ -46,11 +46,18 @@ Overview of the book and what you'll learn.
 - Tool Discovery and Documentation
 - Best Practices
 
+### Chapter 5: [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.html)
+- What GH-AW is and why it matters
+- Workflow structure and compilation
+- Tools, safe inputs, and safe outputs
+- Imports and reusable components
+- ResearchPlanAssign for self-maintaining books
+
 ---
 
 ## How to Read This Book
 
-- **Linear**: Read from Chapter 1 through Chapter 4 for a complete introduction
+- **Linear**: Read from Chapter 1 through Chapter 5 for a complete introduction
 - **Reference**: Jump to specific chapters based on your current needs
 - **Examples**: Focus on code examples to see concepts in action
 - **Practical**: Try implementing the patterns as you read

--- a/index.md
+++ b/index.md
@@ -28,6 +28,9 @@ Build the infrastructure that enables agents to operate effectively.
 ### 🛠️ [Skills and Tools](book/chapters/04-skills-tools.html)
 Master the art of creating, importing, and composing agent capabilities.
 
+### 🧭 [GitHub Agentic Workflows (GH-AW)](book/chapters/05-gh-agentic-workflows.html)
+Learn how GitHub Agentic Workflows turn markdown into secure, composable automation.
+
 ## How This Book Works
 
 1. **Community Suggestions**: Anyone can open an issue with suggestions


### PR DESCRIPTION
### Motivation
- Capture and explain GitHub Agentic Workflows (GH-AW) as an explicit chapter so the book documents the new markdown-to-Actions agentic workflow model.
- Provide a repeatable Research→Plan→Assign playbook to operationalize how this repo discovers, debates, and applies GH-AW-driven updates.
- Surface the new content across site navigation and contributor guidance so readers and agents can find and use the material.

### Description
- Added a new chapter `book/chapters/05-gh-agentic-workflows.md` that explains GH-AW structure, tools, imports, safe inputs/outputs, and the ResearchPlanAssign pattern. 
- Created `WORKFLOW_PLAYBOOK.md` to document the Research→Plan→Assign loop and required artifacts for updates. 
- Added a blog announcement `_posts/2026-02-05-gh-aw-chapter.md` describing the new chapter and playbook. 
- Updated navigation and references in `book/chapters/00-toc.md`, `book/index.md`, `book/README.md`, `index.md`, `README.md`, and `PROJECT_SUMMARY.md` to include Chapter 5 and the playbook. 
- Linked the playbook from `CONTRIBUTING.md` to guide maintainers and agents on the proposed process.

### Testing
- No automated tests were run because these are content-only documentation updates. 
- Recommended manual checks: preview the site locally with Jekyll (`bundle exec jekyll serve`) and verify updated TOC, chapter page, blog post, and contributing link render correctly. 
- No changes to workflows or runtime code were made in this PR, so no runtime validation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6983791c6c0c832da6dee6d61f261b7c)