### PR TITLE
Switch PDF build to xelatex for Unicode support

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Convert to PDF
         run: |
           pandoc combined.md -o agentic-workflows-book.pdf \
-            --pdf-engine=pdflatex \
+            --pdf-engine=xelatex \
             --toc \
             --number-sections \
             -V geometry:margin=1in \

--- a/SETUP.md
+++ b/SETUP.md
@@ -122,7 +122,7 @@ sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive
 
 # Generate PDF
 cat book/README.md book/chapters/*.md > combined.md
-pandoc combined.md -o book.pdf --pdf-engine=pdflatex --toc --number-sections
+pandoc combined.md -o book.pdf --pdf-engine=xelatex --toc --number-sections
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
### Motivation
- The PDF build using `pdflatex` fails on certain Unicode characters (for example U+2198 ↘), so switching to `xelatex` provides better Unicode and font support.

### Description
- Updated `.github/workflows/build-pdf.yml` to use `--pdf-engine=xelatex` instead of `pdflatex`.
- Updated local instructions in `SETUP.md` to use `--pdf-engine=xelatex` for consistency with the workflow.

### Testing
- No automated tests were run; this change only updates the CI workflow and local instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69837d195250832d997dae0fdbe0745b)