### PR TITLE
Simplify homepage and fix relative links

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,56 +3,22 @@ layout: default
 title: Agentic Workflows Book
 ---
 
-# Welcome to the Agentic Workflows Book
+# Agentic Workflows Book
 
-This is a **living book** about agentic workflows, agent orchestration, and agentic scaffolding. What makes it unique is that it maintains itself using the very concepts it teaches!
+[Read the book]({{ "/book/" | relative_url }})
 
-## What Makes This Book Special?
+## Latest posts
 
-- **Self-Updating**: The book automatically incorporates community suggestions through automated workflows
-- **AI-Powered**: GitHub Actions and AI agents collaborate to manage content
-- **Living Documentation**: Always up-to-date with the latest practices and patterns
-- **Open Source**: Community-driven development on GitHub
-
-## What You'll Learn
-
-### 🤖 [Agentic Workflows](book/chapters/01-introduction.html)
-Discover how AI agents can automate complex tasks and adapt to changing requirements.
-
-### 🎭 [Agent Orchestration](book/chapters/02-orchestration.html)
-Learn to coordinate multiple agents working together toward common goals.
-
-### 🏗️ [Agentic Scaffolding](book/chapters/03-scaffolding.html)
-Build the infrastructure that enables agents to operate effectively.
-
-### 🛠️ [Skills and Tools](book/chapters/04-skills-tools.html)
-Master the art of creating, importing, and composing agent capabilities.
-
-### 🧭 [GitHub Agentic Workflows (GH-AW)](book/chapters/05-gh-agentic-workflows.html)
-Learn how GitHub Agentic Workflows turn markdown into secure, composable automation.
-
-### 🤝 [GitHub Agents](book/chapters/06-github-agents.html)
-Explore GitHub Copilot, Copilot Coding Agent, and multi-agent orchestration patterns.
-
-## How This Book Works
-
-1. **Community Suggestions**: Anyone can open an issue with suggestions
-2. **Automated Processing**: Workflows analyze and categorize suggestions
-3. **Agent Writing**: AI agents update content based on approved suggestions
-4. **Automatic Publishing**: Changes are automatically published to GitHub Pages
-5. **Blog Updates**: New posts are created to announce significant updates
-
-## Get Started
-
-- [Read the Full Book](book)
-- [View Latest Blog Posts](blog)
-- [Contribute on GitHub](https://github.com/arivero/agentbook)
-- [Report Issues or Suggestions](https://github.com/arivero/agentbook/issues)
-
-## Recent Updates
-
-Check out our [blog](blog) for the latest updates and additions to the book.
-
----
-
-*This book is an experiment in self-maintaining documentation using agentic workflows. Watch it evolve!*
+{% if site.posts and site.posts.size > 0 %}
+<ul>
+  {% for post in site.posts limit:5 %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <small>{{ post.date | date: "%b %-d, %Y" }}</small>
+  </li>
+  {% endfor %}
+</ul>
+<p><a href="{{ "/blog/" | relative_url }}">View all blog posts</a></p>
+{% else %}
+<p>No blog posts yet. <a href="{{ "/blog/" | relative_url }}">Visit the blog</a>.</p>
+{% endif %}


### PR DESCRIPTION
### Motivation

- Fix broken absolute URLs on the homepage when the site is published under a GitHub Pages base URL and simplify the landing experience to focus visitors on the book and recent posts.
- Reduce verbose homepage content so the site either directs users to the book or shows the most recent blog entries prominently.

### Description

- Replace the verbose `index.md` content with a minimal landing page that links to the book and renders the latest posts using a Liquid loop.
- Use Jekyll's `relative_url` filter for links (for example `"{{ "/book/" | relative_url }}"` and `"{{ post.url | relative_url }}"`) so links resolve correctly under a `baseurl`.
- Add a conditional to show a friendly message when there are no blog posts.

### Testing

- Attempted a site build with `jekyll build`, which failed because `jekyll` is not installed in the environment, so a local preview/build could not be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69838b2208f8832da298313a422f2c03)