### PR TITLE
Automate PDF updates and add repo download link

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   build-pdf:
@@ -45,16 +46,40 @@ jobs:
             -V geometry:margin=1in \
             -V documentclass=report
 
+      - name: Move PDF into repo
+        run: |
+          mkdir -p book
+          mv agentic-workflows-book.pdf book/agentic-workflows-book.pdf
+
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
           name: book-pdf
-          path: agentic-workflows-book.pdf
+          path: book/agentic-workflows-book.pdf
+
+      - name: Create or update PDF PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update generated PDF"
+          title: "Update generated PDF"
+          body: "Automated update of the generated PDF."
+          branch: "automation/update-pdf"
+          delete-branch: true
+          add-paths: |
+            book/agentic-workflows-book.pdf
+
+      - name: Enable auto-merge for PDF PR
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
 
       - name: Create Release on Tag
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: agentic-workflows-book.pdf
+          files: book/agentic-workflows-book.pdf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This book doesn't just teach about agentic workflows—it **uses them**! The boo
 ## 📖 Read the Book
 
 - **Online**: [https://arivero.github.io/agentbook](https://arivero.github.io/agentbook) (GitHub Pages)
-- **PDF**: Download from [GitHub Actions artifacts](https://github.com/arivero/agentbook/actions/workflows/build-pdf.yml)
+- **PDF**: Download from [GitHub Actions artifacts](https://github.com/arivero/agentbook/actions/workflows/build-pdf.yml) or the [repo PDF](https://github.com/arivero/agentbook/raw/main/book/agentic-workflows-book.pdf)
 - **Source**: Browse the [book directory](book)
 
 ## 🎯 What You'll Learn

--- a/book/index.md
+++ b/book/index.md
@@ -73,7 +73,7 @@ Overview of the book and what you'll learn.
 ## Formats
 
 - **Online**: You're reading it now!
-- **PDF**: Download from [GitHub Actions](https://github.com/arivero/agentbook/actions/workflows/build-pdf.yml)
+- **PDF**: Download from [GitHub Actions](https://github.com/arivero/agentbook/actions/workflows/build-pdf.yml) or the [repo PDF](https://github.com/arivero/agentbook/raw/main/book/agentic-workflows-book.pdf)
 - **Source**: Read the [markdown files](https://github.com/arivero/agentbook/tree/main/book) on GitHub
 
 ---


### PR DESCRIPTION
### Motivation
- Ensure the generated PDF is committed back into the repository and can be auto-merged so consumers can easily download a raw copy from the repo.
- Make the PDF easier to discover by adding a direct raw repo PDF link in the docs.

### Description
- Updated `.github/workflows/build-pdf.yml` to grant `contents: write` and `pull-requests: write` permissions and to move the generated PDF into `book/agentic-workflows-book.pdf` after conversion.
- Updated artifact upload and release steps to reference `book/agentic-workflows-book.pdf` so artifacts and releases remain aligned with the in-repo PDF path.
- Added a `peter-evans/create-pull-request@v6` step to commit or update the PDF on branch `automation/update-pdf` and a `peter-evans/enable-pull-request-automerge@v3` step to enable auto-merge using `squash`.
- Added raw repo PDF links to `README.md` and `book/index.md` pointing to `https://github.com/arivero/agentbook/raw/main/book/agentic-workflows-book.pdf`.

### Testing
- No automated tests were run for this change because it only modifies CI workflow configuration and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69838df57498832d8d0a854721e06a47)