### PR TITLE
Add MCP 2026 guidance to Skills & Tools chapter and publish blog post

### DIFF
--- a/_posts/2026-02-06-mcp-2026.md
+++ b/_posts/2026-02-06-mcp-2026.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "MCP in 2026: Interoperable Tools for Agents"
+date: 2026-02-06
+---
+
+We just expanded **Chapter 4: Skills and Tools Management** with a new section on the **Model Context Protocol (MCP)** and how it is used in 2026.
+
+## Why This Matters Now
+
+MCP has shifted from an emerging idea to a **shared tool interoperability layer**. Instead of wiring every assistant to every system, teams define tools once in MCP servers and let multiple clients discover and use them safely.
+
+## What the New Section Covers
+
+- How MCP enables portable tool definitions and safer execution
+- Common 2026 usage patterns (server catalogs, context stitching, permission-first workflows)
+- Realistic adoption notes for **Codex**, **GitHub Copilot**, and **Claude**
+- Practical guidance for documenting and versioning MCP tool contracts
+
+## Read the Update
+
+Head to **Chapter 4** to read the new MCP section and see how it fits into tool design, discovery, and best practices.
+
+---
+
+*As always, this update reflects the book's self-maintaining workflow: observe industry shifts, capture them clearly, and publish concise guidance.*

--- a/book/chapters/00-toc.md
+++ b/book/chapters/00-toc.md
@@ -32,6 +32,7 @@ title: Table of Contents
 4. **[Skills and Tools Management](04-skills-tools.html)**
    - Tools vs. Skills
    - Creating custom tools
+   - MCP in 2026: Modern tooling and adoption
    - Skill development
    - Best practices
 

--- a/book/chapters/04-skills-tools.md
+++ b/book/chapters/04-skills-tools.md
@@ -487,6 +487,53 @@ class DocumentedTool:
         return doc
 ```
 
+## MCP in 2026: Modern Tooling and Adoption
+
+The **Model Context Protocol (MCP)** has become a practical standard for connecting agents to tools and data sources. In 2026, it is less about novel capability and more about **reliable interoperability**: the same tool server can be used by multiple agent clients with consistent schemas, permissions, and response formats.
+
+### What MCP Brings to Tools
+
+- **Portable tool definitions**: JSON schemas and well-known server metadata make tools discoverable across clients.
+- **Safer tool execution**: capability-scoped permissions, explicit parameters, and auditable tool calls.
+- **Composable context**: servers can enrich model context with structured resources (files, APIs, or databases) without bespoke glue code.
+
+### Modern Usage Patterns (2026)
+
+1. **Server-based tool catalogs**
+   - Teams deploy MCP servers per domain (e.g., "repo-tools", "ops-tools", "research-tools").
+   - Clients discover available tools at runtime and choose based on metadata, not hardcoded lists.
+
+2. **Context stitching**
+   - Agents gather context from multiple servers (docs, tickets, metrics) and assemble it into a task-specific prompt.
+   - The server provides structured resources so the client can keep the prompt lean.
+
+3. **Permission-first workflows**
+   - Tool calls are scoped by project, environment, or role.
+   - Audit logs track who called what tool with which inputs.
+
+4. **Fallback-first reliability**
+   - Clients maintain fallbacks when a server is down (cached data, read-only mirrors, or alternative tool servers).
+
+### Acceptance Across Major Clients
+
+MCP is broadly accepted as a **tooling interoperability layer**. The specifics vary by vendor, but the pattern is consistent: MCP servers expose the tools and resources, while clients orchestrate tool calls and manage safety policies.
+
+- **Codex**  
+  Codex clients commonly use MCP servers to standardize tool access (repo browsing, test execution, task automation). MCP reduces per-project wiring by centralizing tool definitions and auth. The main adoption pattern is organization-level MCP servers that provide consistent tools across multiple repos.
+
+- **GitHub Copilot**  
+  Copilot deployments increasingly treat MCP as a bridge between editor experiences and organization tooling. This typically means MCP servers that expose repo-aware tools (search, CI status, documentation retrieval) so the assistant can operate with consistent, policy-driven access.
+
+- **Claude**  
+  Claude integrations often use MCP to provide structured context sources (knowledge bases, issue trackers, dashboards). The MCP server becomes the policy boundary, while the client focuses on prompt composition and response quality.
+
+### Practical Guidance for Authors and Teams
+
+- **Document your MCP servers** like any other tool: include schemas, permissions, and usage examples.
+- **Version tool contracts** so clients can adopt changes incrementally.
+- **Prefer narrow, composable tools** over large monolithic endpoints.
+- **Treat MCP as infrastructure**: invest in uptime, monitoring, and security reviews.
+
 ## Best Practices
 
 ### 1. Version Tools and Skills

--- a/book/index.md
+++ b/book/index.md
@@ -41,6 +41,7 @@ Overview of the book and what you'll learn.
 - Understanding Skills vs. Tools
 - Tool Design Principles
 - Creating Custom Tools
+- MCP in 2026: Modern tooling and adoption
 - Skill Development
 - Importing and Using Skills
 - Tool Discovery and Documentation


### PR DESCRIPTION
### Motivation

- Capture the 2026-practical usage of the Model Context Protocol (MCP) as a shared interoperability layer for agent tooling and context.
- Explain how MCP is accepted in major clients and provide actionable advice for authors and teams on documenting and versioning MCP tool contracts.

### Description

- Add a new "MCP in 2026: Modern Tooling and Adoption" section to `book/chapters/04-skills-tools.md` that covers portable tool definitions, safer execution, context stitching, permission-first workflows, fallback patterns, and vendor adoption notes for Codex, GitHub Copilot, and Claude.
- Update the book table of contents in `book/chapters/00-toc.md` and the book index in `book/index.md` to list the new MCP section.
- Add a blog post `_posts/2026-02-06-mcp-2026.md` announcing the chapter update and summarizing the new MCP guidance.

### Testing

- No automated tests were run because these are documentation-only changes.
- No build or CI checks were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69839064f470832d89c145ec479adb79)