### PR TITLE
Remove trailing TOC link from GitHub Agents chapter

### DIFF
--- a/book/chapters/06-github-agents.md
+++ b/book/chapters/06-github-agents.md
@@ -446,5 +446,3 @@ The workflow is defined in `.github/workflows/process-suggestions.yml` and uses 
 7. **This book** demonstrates these concepts through its own multi-agent maintenance workflow.
 
 ---
-
-*Continue to the next section or return to the [Table of Contents](00-toc.html).*


### PR DESCRIPTION
### Motivation
- Remove the trailing "Continue..." table-of-contents link so the chapter ends cleanly after the final "Key Takeaways" section divider.

### Description
- Deleted the final line linking to the Table of Contents in `book/chapters/06-github-agents.md`, leaving the chapter to end at the section divider after the Key Takeaways.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69839f14ebf0832daf34f3d686d11149)