### PR TITLE
Reorder book chapters and add chapter roadmap

### DIFF
--- a/book/CHAPTER_PLAN.md
+++ b/book/CHAPTER_PLAN.md
@@ -1,0 +1,76 @@
+# Chapter Roadmap
+
+This roadmap reflects the revised chapter ordering and highlights planned enhancements plus key cross-links to dependent chapters.
+
+## Part 1: Foundations
+
+### 1) Introduction to Agentic Workflows
+- **Revised position:** 1 (Foundations)
+- **Enhancement plan:**
+  - Add a short glossary callout for agentic terms introduced in this chapter.
+  - Expand the real-world applications section with two additional case studies.
+  - Add a diagram showing the agent development lifecycle.
+- **Cross-links (dependent chapters):**
+  - [Agent Orchestration](chapters/02-orchestration.md)
+  - [Agentic Scaffolding](chapters/03-scaffolding.md)
+  - [Skills and Tools Management](chapters/04-skills-tools.md)
+  - [GitHub Agents](chapters/06-github-agents.md)
+  - [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
+
+### 2) Agent Orchestration
+- **Revised position:** 2 (Foundations)
+- **Enhancement plan:**
+  - Expand coordination pattern examples with multi-agent decision trees.
+  - Add a comparison table for orchestration frameworks.
+  - Include guidance on observability and telemetry for agent runs.
+- **Cross-links (dependent chapters):**
+  - [Agentic Scaffolding](chapters/03-scaffolding.md)
+  - [Skills and Tools Management](chapters/04-skills-tools.md)
+  - [GitHub Agents](chapters/06-github-agents.md)
+
+## Part 2: Building Blocks
+
+### 3) Agentic Scaffolding
+- **Revised position:** 3 (Building Blocks)
+- **Enhancement plan:**
+  - Add a reference architecture diagram for scaffolded agent systems.
+  - Expand the infrastructure section with environment bootstrapping tips.
+  - Include a checklist for avoiding common scaffolding pitfalls.
+- **Cross-links (dependent chapters):**
+  - [Skills and Tools Management](chapters/04-skills-tools.md)
+  - [GitHub Agents](chapters/06-github-agents.md)
+  - [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
+
+### 4) Skills and Tools Management
+- **Revised position:** 4 (Building Blocks)
+- **Enhancement plan:**
+  - Add a step-by-step guide for skills lifecycle management.
+  - Expand MCP tooling coverage with an updated adoption timeline.
+  - Include a diagram that maps tools vs. skills responsibilities.
+- **Cross-links (dependent chapters):**
+  - [GitHub Agents](chapters/06-github-agents.md)
+  - [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
+
+## Part 3: Applied GitHub Systems
+
+### 5) GitHub Agents
+- **Revised position:** 5 (Applied GitHub Systems)
+- **Enhancement plan:**
+  - Add a walkthrough of a full GitHub Agent scenario.
+  - Expand security considerations with a threat-modeling checklist.
+  - Add a short section on governance and approvals.
+- **Cross-links (dependent chapters):**
+  - [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
+  - [Agent Orchestration](chapters/02-orchestration.md)
+  - [Skills and Tools Management](chapters/04-skills-tools.md)
+
+### 6) GitHub Agentic Workflows (GH-AW)
+- **Revised position:** 6 (Applied GitHub Systems)
+- **Enhancement plan:**
+  - Expand the workflow compilation section with a worked example.
+  - Add a diagram showing safe input/output boundaries.
+  - Include guidance on reusable workflow libraries and templates.
+- **Cross-links (dependent chapters):**
+  - [GitHub Agents](chapters/06-github-agents.md)
+  - [Skills and Tools Management](chapters/04-skills-tools.md)
+  - [Agent Orchestration](chapters/02-orchestration.md)

--- a/book/README.md
+++ b/book/README.md
@@ -10,6 +10,8 @@ This book is a living document that explores the fascinating world of agentic wo
 - **Agent Orchestration**: Coordinating multiple agents to work together effectively
 - **Agentic Scaffolding**: Building the infrastructure for agent-driven development
 - **Skills and Tools**: How to use, import, and compose agent capabilities
+- **GitHub Agents**: Applying agentic patterns within GitHub tooling
+- **GitHub Agentic Workflows**: Building reusable workflows for agent-driven automation
 
 ## Structure
 
@@ -17,7 +19,8 @@ This book is a living document that explores the fascinating world of agentic wo
 2. [Agent Orchestration](chapters/02-orchestration.md)
 3. [Agentic Scaffolding](chapters/03-scaffolding.md)
 4. [Skills and Tools Management](chapters/04-skills-tools.md)
-5. [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
+5. [GitHub Agents](chapters/06-github-agents.md)
+6. [GitHub Agentic Workflows (GH-AW)](chapters/05-gh-agentic-workflows.md)
 
 ## Contributing
 

--- a/book/chapters/00-toc.md
+++ b/book/chapters/00-toc.md
@@ -36,20 +36,20 @@ title: Table of Contents
    - Skill development
    - Best practices
 
-5. **[GitHub Agentic Workflows (GH-AW)](05-gh-agentic-workflows.html)**
-   - What GH-AW is and why it matters
-   - Workflow structure and compilation
-   - Tools, safe inputs, safe outputs
-   - Imports and shared components
-   - ResearchPlanAssign for self-maintaining books
-
-6. **[GitHub Agents](06-github-agents.html)**
+5. **[GitHub Agents](06-github-agents.html)**
    - GitHub Copilot and Copilot Coding Agent
    - Agent capabilities and limitations
    - Multi-agent orchestration patterns
    - Implementing GitHub Agents
    - Security considerations
    - Real-world example: This book
+
+6. **[GitHub Agentic Workflows (GH-AW)](05-gh-agentic-workflows.html)**
+   - What GH-AW is and why it matters
+   - Workflow structure and compilation
+   - Tools, safe inputs, safe outputs
+   - Imports and shared components
+   - ResearchPlanAssign for self-maintaining books
 
 ---
 

--- a/book/chapters/01-introduction.md
+++ b/book/chapters/01-introduction.md
@@ -63,7 +63,7 @@ To work with agentic workflows, you need:
 - Tools and frameworks for agent development
 - Infrastructure for agent execution
 
-In the following chapters, we'll explore how to orchestrate agents, build scaffolding for agent-driven systems, and manage skills and tools effectively.
+In the following chapters, we'll explore how to orchestrate agents, build scaffolding for agent-driven systems, manage skills and tools effectively, and apply those foundations to GitHub Agents and GitHub Agentic Workflows.
 
 ## Key Takeaways
 

--- a/book/index.md
+++ b/book/index.md
@@ -23,8 +23,8 @@ title: "Agentic Workflows: A Practical Guide"
 
 ---
 
-{% include_relative chapters/05-gh-agentic-workflows.md %}
+{% include_relative chapters/06-github-agents.md %}
 
 ---
 
-{% include_relative chapters/06-github-agents.md %}
+{% include_relative chapters/05-gh-agentic-workflows.md %}


### PR DESCRIPTION
### Motivation
- Reorder the book flow to place GitHub Agents before GitHub Agentic Workflows so the GitHub-specific implementation chapter precedes workflow composition guidance. 
- Provide a clear roadmap documenting planned enhancements and cross-chapter dependencies to guide future edits. 
- Update intra-book wording to remove old-order implications and surface the new progression.

### Description
- Reordered the Table of Contents by editing `book/chapters/00-toc.md` to list `GitHub Agents` (06) before `GitHub Agentic Workflows` (05). 
- Updated the book overview in `book/README.md` and the rendered book assembly in `book/index.md` to reflect the new chapter sequence. 
- Adjusted the introduction language in `book/chapters/01-introduction.md` to mention the GitHub-focused chapters in the forward-looking sentence. 
- Added `book/CHAPTER_PLAN.md`, a chapter roadmap with revised positions, 3–5 item enhancement plans per chapter, and cross-links to dependent chapters.

### Testing
- Ran `rg` searches to locate phrasing like "following chapters" and "next section" and confirmed the introduction was updated where found. 
- Printed and reviewed the affected files with `nl`, `sed`, and `cat` to verify the TOC, README, index, and introduction reflect the new order. 
- Ran `git status` and performed a `git commit` which succeeded, confirming the changes were staged and recorded; no unit or CI test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69839f333a44832da7757de58309096c)