### PR TITLE
Replace Unicode diagrams with ASCII and improve PDF build

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -35,34 +35,18 @@ jobs:
 
       - name: Combine markdown files
         run: |
-          cat book/chapters/00-front-matter.md > combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/01-introduction.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/02-orchestration.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/03-scaffolding.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/04-skills-tools.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/05-gh-agentic-workflows.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/06-github-agents.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/07-agents-for-coding.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/08-agents-for-math-physics.md >> combined.md
-          echo -e "\n\n" >> combined.md
-          cat book/chapters/99-bibliography.md >> combined.md
+          chmod +x scripts/build-combined-md.sh
+          scripts/build-combined-md.sh combined.md
 
       - name: Convert to PDF
         run: |
           pandoc combined.md -o agentic-workflows-book.pdf \
             --pdf-engine=xelatex \
-            --toc \
             --number-sections \
             -V geometry:margin=1in \
-            -V documentclass=report
+            -V documentclass=report \
+            --listings \
+            --include-in-header=book/pandoc/latex-header.tex
 
       - name: Move PDF into repo
         run: |

--- a/book/chapters/00-front-matter.md
+++ b/book/chapters/00-front-matter.md
@@ -25,6 +25,9 @@ order: 0
 \end{center}
 \newpage
 
+\tableofcontents
+\newpage
+
 # Copyright {-}
 
 Copyright © 2026 Agentbook Contributors. All rights reserved.

--- a/book/chapters/00-toc.md
+++ b/book/chapters/00-toc.md
@@ -21,4 +21,4 @@ order: 0
 
 ---
 
-[← Back to Book Home](../index.html)
+[<- Back to Book Home](../index.html)

--- a/book/chapters/02-orchestration.md
+++ b/book/chapters/02-orchestration.md
@@ -21,20 +21,20 @@ Agent orchestration is the art and science of coordinating multiple agents to wo
 Agents work one after another, each building on previous results.
 
 ```text
-Agent A → Agent B → Agent C → Result
+Agent A -> Agent B -> Agent C -> Result
 ```
 
 **Use cases**:
-- Code generation → Testing → Deployment
-- Data collection → Analysis → Reporting
+- Code generation -> Testing -> Deployment
+- Data collection -> Analysis -> Reporting
 
 ### Parallel Execution
 Multiple agents work simultaneously on independent tasks.
 
 ```text
-Agent A ↘
-Agent B → Aggregator → Result
-Agent C ↗
+Agent A \
+Agent B -> Aggregator -> Result
+Agent C /
 ```
 
 **Use cases**:
@@ -46,9 +46,9 @@ A supervisor agent delegates tasks to specialized worker agents.
 
 ```text
 Supervisor Agent
-    ├─> Worker A
-    ├─> Worker B
-    └─> Worker C
+    |--> Worker A
+    |--> Worker B
+    `--> Worker C
 ```
 
 **Use cases**:
@@ -59,7 +59,7 @@ Supervisor Agent
 Agents respond to events and trigger other agents.
 
 ```text
-Event → Agent A → Event → Agent B → Event → Agent C
+Event -> Agent A -> Event -> Agent B -> Event -> Agent C
 ```
 
 **Use cases**:

--- a/book/chapters/03-scaffolding.md
+++ b/book/chapters/03-scaffolding.md
@@ -325,11 +325,11 @@ This book's scaffolding includes:
 
 ## Common Pitfalls
 
-❌ **Over-engineering**: Don't build scaffolding for hypothetical needs
-❌ **Tight Coupling**: Keep agents loosely coupled to scaffolding
-❌ **Poor Error Handling**: Always plan for failure scenarios
-❌ **No Monitoring**: You can't improve what you can't measure
-❌ **Ignoring Security**: Security must be built in, not bolted on
+X **Over-engineering**: Don't build scaffolding for hypothetical needs
+X **Tight Coupling**: Keep agents loosely coupled to scaffolding
+X **Poor Error Handling**: Always plan for failure scenarios
+X **No Monitoring**: You can't improve what you can't measure
+X **Ignoring Security**: Security must be built in, not bolted on
 
 ## Key Takeaways
 

--- a/book/chapters/04-skills-tools.md
+++ b/book/chapters/04-skills-tools.md
@@ -917,13 +917,13 @@ AGENTS.md files can be placed hierarchically in a project:
 
 ```text
 project/
-├── AGENTS.md           # Root-level instructions (project-wide)
-├── src/
-│   └── AGENTS.md       # Module-specific instructions
-├── tests/
-│   └── AGENTS.md       # Testing conventions
-└── docs/
-    └── AGENTS.md       # Documentation guidelines
+|-- AGENTS.md           # Root-level instructions (project-wide)
+|-- src/
+|   `-- AGENTS.md       # Module-specific instructions
+|-- tests/
+|   `-- AGENTS.md       # Testing conventions
+`-- docs/
+    `-- AGENTS.md       # Documentation guidelines
 ```
 
 Agents use the nearest AGENTS.md file, enabling scoped configuration for monorepos or complex projects.

--- a/book/chapters/05-gh-agentic-workflows.md
+++ b/book/chapters/05-gh-agentic-workflows.md
@@ -66,10 +66,10 @@ Both the source markdown files and the compiled `.lock.yml` files live in the `.
 
 ```text
 .github/workflows/
-├── triage.md          # Source (human-editable)
-├── triage.lock.yml    # Compiled (auto-generated, do not edit)
-├── docs-refresh.md
-└── docs-refresh.lock.yml
+|-- triage.md          # Source (human-editable)
+|-- triage.lock.yml    # Compiled (auto-generated, do not edit)
+|-- docs-refresh.md
+`-- docs-refresh.lock.yml
 ```
 
 Use `gh aw compile` (from the GH-AW CLI at <https://github.com/github/gh-aw>) in your repository root to generate `.lock.yml` files from your markdown sources. Only edit the `.md` files; the `.lock.yml` files are regenerated on compile.

--- a/book/chapters/06-github-agents.md
+++ b/book/chapters/06-github-agents.md
@@ -130,7 +130,7 @@ Single agents have limitations. Multi-agent systems provide:
 Agents work in sequence, each building on the previous:
 
 ```text
-Issue → ACK Agent → Research Agent → Writer Agent → Review Agent → Complete
+Issue -> ACK Agent -> Research Agent -> Writer Agent -> Review Agent -> Complete
 ```
 
 **Example workflow stages:**
@@ -175,7 +175,7 @@ jobs:
 Agents work until human decision is needed:
 
 ```text
-Agents work → Human checkpoint → Agents continue
+Agents work -> Human checkpoint -> Agents continue
 ```
 
 This pattern is essential for:
@@ -283,7 +283,7 @@ Agents should handle failures gracefully:
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: context.issue.number,
-          body: `⚠️ Agent encountered an error: ${error.message}`
+          body: `WARNING: Agent encountered an error: ${error.message}`
         });
       }
 ```
@@ -406,22 +406,22 @@ This very book uses GitHub Agents for self-maintenance:
 ### How It Works
 
 ```text
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│    Issue    │ ──▶ │ ACK Agent   │ ──▶ │  Research   │
-│   Opened    │     │             │     │   Agent     │
-└─────────────┘     └─────────────┘     └─────────────┘
-                                               │
-                                               ▼
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  Complete   │ ◀── │   Writer    │ ◀── │  Multi-Model│
-│   Agent     │     │   Agent     │     │  Discussion │
-└─────────────┘     └─────────────┘     └─────────────┘
-                          │
-                          ▼
-                    ┌─────────────┐
-                    │  Human      │
-                    │  Review     │
-                    └─────────────┘
++-------------+     +-------------+     +-------------+
+| Issue       | --> | ACK Agent   | --> | Research    |
+| Opened      |     |             |     | Agent       |
++-------------+     +-------------+     +-------------+
+                                               |
+                                               v
++-------------+     +-------------+     +-------------+
+| Complete    | <-- | Writer      | <-- | Multi-Model |
+| Agent       |     | Agent       |     | Discussion  |
++-------------+     +-------------+     +-------------+
+                          |
+                          v
+                    +-------------+
+                    | Human       |
+                    | Review      |
+                    +-------------+
 ```
 
 ### Configuration
@@ -507,12 +507,12 @@ Example hierarchy:
 
 ```text
 project/
-├── AGENTS.md                      # Canonical agent instructions
-├── CLAUDE.md                      # Claude-specific (may reference AGENTS.md)
-├── .github/
-│   └── copilot-instructions.md    # Copilot-specific (may reference AGENTS.md)
-└── src/
-    └── AGENTS.md                  # Module-specific instructions
+|-- AGENTS.md                      # Canonical agent instructions
+|-- CLAUDE.md                      # Claude-specific (may reference AGENTS.md)
+|-- .github/
+|   `-- copilot-instructions.md    # Copilot-specific (may reference AGENTS.md)
+`-- src/
+    `-- AGENTS.md                  # Module-specific instructions
 ```
 
 ### This Repository's Approach

--- a/book/chapters/07-agents-for-coding.md
+++ b/book/chapters/07-agents-for-coding.md
@@ -220,13 +220,13 @@ The **AGENTS.md** file has emerged as the de facto standard for providing AI cod
 
 ```text
 project/
-├── AGENTS.md           # Root-level agent instructions
-├── src/
-│   └── AGENTS.md       # Module-specific instructions
-├── tests/
-│   └── AGENTS.md       # Testing conventions
-└── docs/
-    └── AGENTS.md       # Documentation guidelines
+|-- AGENTS.md           # Root-level agent instructions
+|-- src/
+|   `-- AGENTS.md       # Module-specific instructions
+|-- tests/
+|   `-- AGENTS.md       # Testing conventions
+`-- docs/
+    `-- AGENTS.md       # Documentation guidelines
 ```
 
 Agents use the nearest AGENTS.md file, enabling scoped configuration for monorepos or complex projects.

--- a/book/pandoc/latex-header.tex
+++ b/book/pandoc/latex-header.tex
@@ -1,0 +1,21 @@
+\usepackage{listings}
+\usepackage{xcolor}
+
+\definecolor{codegray}{HTML}{F2F2F2}
+\definecolor{coderule}{HTML}{D0D0D0}
+
+\lstset{
+  basicstyle=\ttfamily\small,
+  backgroundcolor=\color{codegray},
+  frame=single,
+  rulecolor=\color{coderule},
+  frameround=ffff,
+  breaklines=true,
+  columns=fullflexible,
+  keepspaces=true,
+  showstringspaces=false,
+  xleftmargin=0.5em,
+  xrightmargin=0.5em,
+  framexleftmargin=0.5em,
+  framexrightmargin=0.5em
+}

--- a/scripts/build-combined-md.sh
+++ b/scripts/build-combined-md.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output="${1:-combined.md}"
+
+chapter_glob="book/chapters/*-*.md"
+
+strip_yaml_front_matter() {
+  awk 'NR==1 && $0=="---" {in_yaml=1; next}
+       in_yaml && $0=="---" {in_yaml=0; next}
+       in_yaml {next}
+       {print}' "$1"
+}
+
+: > "$output"
+
+printf '%s\n' $chapter_glob | LC_ALL=C sort | while read -r chapter; do
+  strip_yaml_front_matter "$chapter" >> "$output"
+  printf "\n\n" >> "$output"
+done


### PR DESCRIPTION
### Motivation
- Avoid missing-glyph warnings and PDF rendering issues by replacing Unicode arrows, box-drawing characters, and emoji with plain ASCII equivalents across chapter content.
- Make combined-markdown generation deterministic and reusable by moving concatenation into a small script that strips per-file YAML frontmatter.

### Description
- Replace Unicode arrows/diagrams and the warning emoji with ASCII equivalents in multiple chapters under `book/chapters/` to ensure consistent rendering in the generated PDF.
- Add `scripts/build-combined-md.sh`, which globs `book/chapters/*-*.md`, sorts the matches, strips YAML frontmatter via `strip_yaml_front_matter`, and concatenates them into a single output file.
- Update the PDF build to use the new script and add `book/pandoc/latex-header.tex` to enable consistent code block styling, and insert `\tableofcontents` into `book/chapters/00-front-matter.md` so the TOC appears in the PDF.
- Convert repository-tree and backlink glyphs to ASCII (e.g. `|--`, `+--`, `<-`) for consistent plain-text diagrams.

### Testing
- Ran `bash scripts/build-combined-md.sh /tmp/combined.md` and it completed successfully.
- Generated a PDF with `pandoc /tmp/combined.md -o /tmp/agentic-workflows-book.pdf --pdf-engine=xelatex --number-sections -V geometry:margin=1in -V documentclass=report --listings --include-in-header=book/pandoc/latex-header.tex` and the run completed successfully with no missing-glyph warnings.
- Verified no remaining diagram/unicode glyphs by searching the chapters with `rg` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6983e70181d8832da0722ec847c6add0)