### PR TITLE
Skip Jekyll TOC page when building combined Markdown for PDF

### DIFF
--- a/scripts/build-combined-md.sh
+++ b/scripts/build-combined-md.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 output="${1:-combined.md}"
 
 chapter_glob="book/chapters/*-*.md"
+exclude_files=(
+  "book/chapters/00-toc.md"
+)
 
 strip_yaml_front_matter() {
   awk 'NR==1 && $0=="---" {in_yaml=1; next}
@@ -15,6 +18,18 @@ strip_yaml_front_matter() {
 : > "$output"
 
 printf '%s\n' $chapter_glob | LC_ALL=C sort | while read -r chapter; do
+  skip=false
+  for excluded in "${exclude_files[@]}"; do
+    if [[ "$chapter" == "$excluded" ]]; then
+      skip=true
+      break
+    fi
+  done
+
+  if [[ "$skip" == true ]]; then
+    continue
+  fi
+
   strip_yaml_front_matter "$chapter" >> "$output"
   printf "\n\n" >> "$output"
 done


### PR DESCRIPTION
### Motivation
- The Jekyll/Liquid TOC source page (`book/chapters/00-toc.md`) was being included in the Pandoc input and rendered as a spurious chapter in the generated PDF.
- Excluding the TOC source prevents Liquid template markup from appearing in `combined.md` and the final PDF.

### Description
- Add an `exclude_files` array to `scripts/build-combined-md.sh` containing `book/chapters/00-toc.md`.
- Add a skip loop in the chapter-processing pipeline to ignore any matching excluded files before stripping YAML front-matter.
- Preserve the existing YAML front-matter stripping logic and processing order for all real chapter files.

### Testing
- Ran `bash scripts/build-combined-md.sh /tmp/combined.md` and the command completed successfully.
- Inspected the generated `/tmp/combined.md` and confirmed it no longer contains TOC/Liquid lines (for example `chapter_pages`, `Book Home`, or `Back to Book Home`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698432334a8c832d9cab4084a965b699)