### PR TITLE
Add final chapter on failure modes; clarify snippets, LangChain examples, skills layout, and docs

### DIFF
--- a/book/chapters/00-front-matter.md
+++ b/book/chapters/00-front-matter.md
@@ -44,7 +44,10 @@ You should be comfortable with Git, GitHub Actions, and basic software engineeri
 - **Inline code** is shown in a monospaced font.
 - **File names** appear above code blocks (Example 4-2, etc.).
 - **Commands** use fenced code blocks with a language tag.
-- **Code samples** are illustrative pseudocode unless explicitly labeled “Runnable.”
+- **Code samples** include a snippet-status label when version drift is likely:
+  - **Runnable**: intended to run with minor adaptation, usually with a version/date note.
+  - **Illustrative pseudocode**: architecture pattern, not copy/paste ready.
+  - **Simplified**: runnable shape, but omits production details (auth, retries, error handling).
 - **Tip**, **Note**, and **Warning** callouts highlight critical guidance.
 
 > **Tip:** Prefer pinned action SHAs in CI workflows that handle secrets.

--- a/book/chapters/02-orchestration.md
+++ b/book/chapters/02-orchestration.md
@@ -150,19 +150,22 @@ jobs:
 
 ### LangChain
 LangChain (<https://python.langchain.com/>) is a Python framework for LLM applications:
+
+> **Snippet status:** Runnable example pattern (validated against LangChain v1 docs, Feb 2026; verify exact signature in your installed version).
+
 ```python
-from langchain.agents import AgentExecutor
 from langchain.agents import create_agent
 
 agent = create_agent(
-    llm=llm,
+    model="gpt-4o-mini",
     tools=tools,
-    prompt=prompt
+    system_prompt="You are a helpful workflow orchestrator.",
 )
 
-executor = AgentExecutor(agent=agent, tools=tools)
-result = executor.run("Your task here")
+result = agent.invoke({"messages": [{"role": "user", "content": "Your task here"}]})
 ```
+
+> **Note:** LangChain's agents API has evolved quickly. Prefer the current docs for exact signatures, and treat older snippets that pass `llm=` directly as version-specific patterns.
 
 ### Custom Orchestration
 Build your own orchestrator:

--- a/book/chapters/03-scaffolding.md
+++ b/book/chapters/03-scaffolding.md
@@ -79,7 +79,7 @@ Provide safe, isolated environments for agent execution.
 
 ```yaml
 # Docker-based agent environment
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # Install dependencies
 RUN pip install langchain openai requests

--- a/book/chapters/04-skills-tools.md
+++ b/book/chapters/04-skills-tools.md
@@ -273,24 +273,28 @@ For practical interoperability, treat **Agent Skills** as the primary standard t
 
 The current ecosystem signal is strongest around this filesystem-first model: a `SKILL.md` contract with progressive disclosure, plus optional `scripts/`, `references/`, and `assets/` directories.
 
+> **Placement note:** For OpenAI Codex auto-discovery, store repository skills under `.agents/skills/` (or user-level `~/.codex/skills/`). A plain top-level `skills/` folder is a useful wrapper convention but is not auto-discovered by default without additional wiring.
+
+
 ### Canonical Layout
 
-Example 4-1. `skills/code-review/`
+Example 4-1. `.agents/skills/code-review/`
 
 ```text
-skills/
-  code-review/
-    SKILL.md
-    manifest.json
-    scripts/
-      review.py
-    references/
-      rubric.md
-    assets/
-      example-diff.txt
+.agents/
+  skills/
+    code-review/
+      SKILL.md
+      manifest.json
+      scripts/
+        review.py
+      references/
+        rubric.md
+      assets/
+        example-diff.txt
 ```
 
-Example 4-2. `skills/code-review/SKILL.md`
+Example 4-2. `.agents/skills/code-review/SKILL.md`
 
 ```markdown
 ---
@@ -654,21 +658,26 @@ Several other frameworks share architectural patterns with OpenClaw:
 
 ### LangChain and LangGraph
 
-LangChain (<https://python.langchain.com/>) provides composable building blocks for LLM applications:
+LangChain (<https://python.langchain.com/>) provides composable building blocks for LLM applications.
+
+> **Snippet status:** Illustrative pseudocode (API names vary across LangChain versions).
 
 ```python
-from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain.agents import create_agent
 from langchain_core.tools import tool
 
 @tool
 def search_documentation(query: str) -> str:
     """Search project documentation for relevant information."""
     # Implementation
-    pass
+    return "..."
 
-# Create agent with tools
-agent = create_tool_calling_agent(llm, tools=[search_documentation], prompt=prompt)
-executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+agent = create_agent(
+    model="gpt-4o-mini",
+    tools=[search_documentation],
+    system_prompt="Use tools when needed, then summarize clearly.",
+)
+result = agent.invoke({"messages": [{"role": "user", "content": "Find testing docs"}]})
 ```
 
 **Shared patterns with OpenClaw**: Tool registration, agent composition, memory management.

--- a/book/chapters/07-github-agents.md
+++ b/book/chapters/07-github-agents.md
@@ -441,7 +441,7 @@ Modern repositories need to support multiple AI agent platforms. Different codin
 When multiple AI agents work with your repository, you face a coordination challenge:
 
 - **GitHub Copilot** reads `.github/copilot-instructions.md` for project-specific guidance
-- **Claude** uses `CLAUDE.md` for dedicated configuration, or can read `AGENTS.md` files for project context
+- **Claude** automatically incorporates `CLAUDE.md`; `AGENTS.md` may still be useful as shared project documentation, but should be explicitly referenced for reliable Claude workflows
 - **OpenAI Codex (GPT-5.2-Codex)** can be configured with system instructions and skills packaged via `SKILL.md` (see <https://platform.openai.com/docs/guides/codex/skills>)
 - **Generic agents** look for `AGENTS.md` as the emerging standard
 
@@ -498,9 +498,9 @@ Describe important directories and their purposes.
 
 For maximum compatibility across AI agent platforms, follow these practices:
 
-1. **Use AGENTS.md as the canonical source** for project instructions
-2. **Create platform-specific files** that import or reference AGENTS.md content
-3. **Keep instructions DRY** by avoiding duplication across files
+1. **Pick a canonical source per platform** (`AGENTS.md` for many coding agents, `CLAUDE.md` for Claude)
+2. **Cross-reference shared guidance** between platform files to reduce drift
+3. **Keep instructions DRY** by avoiding unnecessary duplication
 4. **Test with multiple agents** to ensure instructions work correctly
 
 Example hierarchy:

--- a/book/chapters/10-failure-modes-testing-fixes.md
+++ b/book/chapters/10-failure-modes-testing-fixes.md
@@ -1,0 +1,302 @@
+---
+title: "Common Failure Modes, Testing, and Fixes"
+order: 10
+---
+
+# Common Failure Modes, Testing, and Fixes
+
+## Chapter Goals
+
+By the end of this chapter, you should be able to:
+
+- Recognize the most common ways agentic workflows fail in production.
+- Design a test strategy that catches failures before deployment.
+- Apply practical mitigation and recovery patterns.
+- Turn incidents into durable process and architecture improvements.
+
+## Why Failures Are Different in Agentic Systems
+
+Traditional software failures are often deterministic and reproducible. Agent failures can also include:
+
+- **Nondeterminism** from model sampling and external context.
+- **Tool and API variance** across environments and versions.
+- **Instruction ambiguity** when prompts, policy files, or skills conflict.
+- **Long-horizon drift** where behavior degrades over many steps.
+
+This means reliability work must combine classic software testing with scenario-based evaluation and operational controls.
+
+## Failure Taxonomy
+
+Use this taxonomy to classify incidents quickly and choose the right fix path.
+
+### 1) Planning and Reasoning Failures
+
+Symptoms:
+
+- Agent picks the wrong sub-goal.
+- Repeats work or loops without convergence.
+- Produces plausible but invalid conclusions.
+
+Typical causes:
+
+- Missing constraints in system instructions.
+- Overly broad tasks with no decomposition guardrails.
+- No termination criteria.
+
+Fast fixes:
+
+- Add explicit success criteria and stop conditions.
+- Break tasks into bounded steps.
+- Require intermediate checks before irreversible actions.
+
+### 2) Tooling and Integration Failures
+
+Symptoms:
+
+- Tool calls fail intermittently.
+- Wrong parameters passed to tools.
+- Tool output parsed incorrectly.
+
+Typical causes:
+
+- Schema drift or undocumented API changes.
+- Weak input validation.
+- Inconsistent retry/backoff handling.
+
+Fast fixes:
+
+- Validate tool contracts at runtime.
+- Add strict argument schemas.
+- Standardize retries with idempotency keys.
+
+### 3) Context and Memory Failures
+
+Symptoms:
+
+- Agent forgets prior constraints.
+- Important instructions are dropped when context grows.
+- Stale memories override fresh data.
+
+Typical causes:
+
+- Context window pressure.
+- Poor memory ranking/retrieval.
+- Missing recency and source-quality weighting.
+
+Fast fixes:
+
+- Introduce context budgets and summarization checkpoints.
+- Add citation requirements for retrieved facts.
+- Expire or down-rank stale memory entries.
+
+### 4) Safety and Policy Failures
+
+Symptoms:
+
+- Sensitive files modified unexpectedly.
+- Security constraints bypassed through tool chains.
+- Unsafe suggestions in generated code.
+
+Typical causes:
+
+- Weak policy enforcement boundaries.
+- No pre-merge policy gates.
+- Implicit trust in generated output.
+
+Fast fixes:
+
+- Enforce allow/deny lists at tool gateway level.
+- Require policy checks in CI.
+- Route high-risk actions through human approval.
+
+### 5) Collaboration and Workflow Failures
+
+Symptoms:
+
+- Multiple agents make conflicting changes.
+- PRs churn with contradictory edits.
+- Work stalls due to unclear ownership.
+
+Typical causes:
+
+- Missing orchestration contracts.
+- No lock/lease model for shared resources.
+- Role overlap without clear handoff rules.
+
+Fast fixes:
+
+- Add ownership rules per path/component.
+- Use optimistic locking with conflict resolution policy.
+- Define role-specific done criteria.
+
+## Testing Strategy for Agentic Workflows
+
+A robust strategy uses multiple test layers. No single test type is sufficient.
+
+## 1. Static and Structural Checks
+
+Use these to fail fast before expensive model execution:
+
+- Markdown/schema validation for instruction files.
+- Prompt template linting.
+- Tool interface compatibility checks.
+- Dependency and version constraint checks.
+
+## 2. Deterministic Unit Tests (Without LLM Calls)
+
+Test orchestration logic, parsers, and guards deterministically:
+
+- State transitions.
+- Retry and timeout behavior.
+- Permission checks.
+- Conflict resolution rules.
+
+> **Snippet status:** Runnable shape (simplified for clarity).
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class StepResult:
+    ok: bool
+    retryable: bool
+
+
+def should_retry(result: StepResult, attempt: int, max_attempts: int = 3) -> bool:
+    return (not result.ok) and result.retryable and attempt < max_attempts
+
+
+def test_retry_policy():
+    assert should_retry(StepResult(ok=False, retryable=True), attempt=1)
+    assert not should_retry(StepResult(ok=False, retryable=False), attempt=1)
+    assert not should_retry(StepResult(ok=False, retryable=True), attempt=3)
+```
+
+## 3. Recorded Integration Tests (Golden Traces)
+
+Capture representative interactions and replay them against newer builds:
+
+- Record tool inputs/outputs.
+- Freeze external dependencies where possible.
+- Compare final artifacts and decision traces.
+
+Use these to detect drift in behavior after prompt/tool/model changes.
+
+## 4. Scenario and Adversarial Evaluations
+
+Design "challenge suites" for known weak spots:
+
+- Ambiguous requirements.
+- Contradictory documentation.
+- Missing dependencies.
+- Partial outages and degraded APIs.
+- Prompt-injection attempts in retrieved content.
+
+Pass criteria should include not just correctness, but also:
+
+- Policy compliance.
+- Cost/latency ceilings.
+- Evidence quality (citations, rationale quality).
+
+## 5. Production Guardrail Tests
+
+Before enabling autonomous writes/merges in production, validate:
+
+- Protected-path enforcement.
+- Secret scanning and license checks.
+- Human approval routing for high-impact actions.
+- Rollback path on failed deployments.
+
+## Practical Fix Patterns
+
+When incidents happen, reusable fix patterns reduce MTTR (mean time to recovery).
+
+### Pattern A: Contract Hardening
+
+- Add strict schemas between planner and tool runner.
+- Reject malformed or out-of-policy requests early.
+- Version contracts (`v1`, `v2`) and support migrations.
+
+### Pattern B: Progressive Autonomy
+
+- Start in "suggest-only" mode.
+- Move to "execute with review" mode.
+- Graduate to autonomous mode only after SLO compliance.
+
+### Pattern C: Two-Phase Execution
+
+1. **Plan phase**: generate proposed actions and expected effects.
+2. **Apply phase**: execute only after policy and validation checks pass.
+
+This reduces irreversible mistakes and improves auditability.
+
+### Pattern D: Fallback and Circuit Breakers
+
+- If tool failure rate spikes, disable affected paths automatically.
+- Fall back to a safer baseline workflow.
+- Alert operators with incident context.
+
+### Pattern E: Human-in-the-Loop Escalation
+
+Define explicit escalation triggers:
+
+- Repeated retries without progress.
+- Any request touching protected paths.
+- Low-confidence output in high-risk domains.
+
+## Incident Response Runbook (Template)
+
+Use a lightweight runbook so teams respond consistently:
+
+1. **Detect**: Alert from CI, runtime monitor, or user report.
+2. **Classify**: Map to taxonomy category.
+3. **Contain**: Stop autonomous actions if blast radius is unclear.
+4. **Diagnose**: Reproduce with trace + config snapshot.
+5. **Mitigate**: Apply short-term guardrails/fallback.
+6. **Fix**: Implement structural correction.
+7. **Verify**: Re-run affected test suites + adversarial cases.
+8. **Learn**: Add regression test and update docs.
+
+## Metrics That Actually Matter
+
+Track these to evaluate reliability improvements over time:
+
+- **Task success rate** (with policy compliance as part of success).
+- **Intervention rate** (how often humans must correct the agent).
+- **Escaped defect rate** (failures discovered after merge/deploy).
+- **Mean time to detect (MTTD)** and **mean time to recover (MTTR)**.
+- **Cost per successful task** and **latency percentiles**.
+
+Avoid vanity metrics (for example, "number of agent runs") without quality and safety context.
+
+## Anti-Patterns to Avoid
+
+- Treating prompt edits as sufficient reliability work.
+- Allowing autonomous writes without protected-path policies.
+- Skipping regression suites after model/version upgrades.
+- Relying on a single benchmark instead of diverse scenarios.
+- Ignoring ambiguous ownership in multi-agent flows.
+
+## A Minimal Reliability Checklist
+
+Before enabling broad production use, confirm:
+
+- [ ] Snippets and examples are clearly labeled (runnable/pseudocode/simplified).
+- [ ] Tool contracts are versioned and validated.
+- [ ] CI includes policy, security, and regression checks.
+- [ ] Failure injection scenarios are part of routine testing.
+- [ ] Rollback and escalation paths are documented and exercised.
+
+## Chapter Summary
+
+Reliable agentic systems are built, not assumed. Teams that combine:
+
+- clear contracts,
+- layered testing,
+- progressive autonomy,
+- strong policy gates, and
+- incident-driven learning
+
+consistently outperform teams relying on prompt-only tuning.
+
+In practice, your competitive advantage comes from how quickly you detect, contain, and permanently fix failures—not from avoiding them entirely.

--- a/book/chapters/99-bibliography.md
+++ b/book/chapters/99-bibliography.md
@@ -8,8 +8,8 @@ order: 99
 - GitHub Agentic Workflows documentation. <https://github.github.io/gh-aw/>. Accessed: 2026-02-05.
 - GitHub Agentic Workflows repository. <https://github.com/github/gh-aw>. Accessed: 2026-02-05.
 - GitHub Copilot documentation. <https://docs.github.com/en/copilot>. Accessed: 2026-02-05.
-- GitHub Copilot coding agent. <https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent>. Accessed: 2026-02-05.
-- Copilot coding agent environment customization. <https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment>. Accessed: 2026-02-05.
+- GitHub Copilot coding agent. [GitHub Docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent). Accessed: 2026-02-05.
+- Copilot coding agent environment customization. [GitHub Docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment). Accessed: 2026-02-05.
 - Model Context Protocol (MCP). <https://modelcontextprotocol.io/>. Accessed: 2026-02-05.
 - Skills Protocol documentation. <https://skillsprotocol.com/>. Accessed: 2026-02-05.
 - Skills Protocol Implementation Guide. <https://skillsprotocol.com/implementation-guide>. Accessed: 2026-02-05.


### PR DESCRIPTION
### Motivation

- Provide operational guidance on reliability and drift by adding a comprehensive final chapter covering failure taxonomy, layered testing, fix patterns, and an incident runbook.
- Reduce confusion from API drift and snippet ambiguity by making snippet intent explicit and modernizing examples that frequently rot (LangChain patterns, placement of skills, platform guidance). 
- Improve developer experience and portability by updating an example runtime base image and making repository-level agent guidance clearer across platforms. 

### Description

- Added a new chapter `book/chapters/10-failure-modes-testing-fixes.md` (order: 10) that documents common failure modes, multi-layered testing strategies, practical fix patterns, an incident response runbook, reliability metrics, anti-patterns, and a minimal pre-production checklist. 
- Clarified code-sample intent in `book/chapters/00-front-matter.md` by adding a `snippet-status` convention (`Runnable`, `Illustrative pseudocode`, `Simplified`).
- Modernized LangChain examples and call-sites in `book/chapters/02-orchestration.md` and `book/chapters/04-skills-tools.md` to use `create_agent(...)` / `agent.invoke(...)` shapes, added a `Runnable`/`Illustrative pseudocode` note, and adjusted import lines to reflect current API shape. 
- Fixed skill placement guidance and canonical layout in `book/chapters/04-skills-tools.md` to use `.agents/skills/...` with a `Placement note` for OpenAI Codex auto-discovery. 
- Bumped the example Docker base image to `python:3.11-slim` in `book/chapters/03-scaffolding.md`. 
- Clarified cross-platform agent documentation guidance for Claude/`AGENTS.md` in `book/chapters/07-github-agents.md`. 
- Replaced fragile raw URLs with markdown-style links in `book/chapters/99-bibliography.md` for clearer references. 

### Testing

- Ran `git diff --check` to validate there are no trailing-whitespace or diff errors and it completed successfully. 
- Verified chapter ordering and presence with `rg -n "^order:" book/chapters/*.md` and searched for key headings in the new chapter with `rg -n "Common Failure Modes, Testing, and Fixes|Incident Response Runbook|Minimal Reliability Checklist" book/chapters/10-failure-modes-testing-fixes.md`, both succeeded. 
- Confirmed file content with `nl -ba book/chapters/10-failure-modes-testing-fixes.md | sed -n '1,360p'` and committed the changes; `git status --short` reported the new file and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69843fe50688832d92f3f2a37754d313)