### PR TITLE
docs: clarify intake ACK dispatches routing via workflow_dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ agentbook/
 
 ## 🔧 Automation
 
-This repository uses GitHub Actions and GH-AW workflows for publishing, validation, and issue-processing.
+This repository uses GitHub Actions and GH-AW workflows for publishing, validation, and issue-processing. The issue intake ACK workflow dispatches the routing workflow via `workflow_dispatch`.
 
 For workflow lifecycle details, see [WORKFLOW_PLAYBOOK.md](WORKFLOW_PLAYBOOK.md).
 For required operator setup (tokens, permissions, and operating checklist), use [content.md](content.md). This is the guide for the required human operator.


### PR DESCRIPTION
`Fixes #104`

## Summary

Added one sentence to the Automation section of README.md clarifying that the issue intake ACK workflow dispatches the routing workflow via `workflow_dispatch`.

## Changes

- **README.md**: Added sentence in the 🔧 Automation section explaining the dispatch mechanism

## Testing

- ✅ Change is documentation-only
- ✅ Minimal, safe update as requested
- ✅ Follows existing style and formatting


> AI generated by [GH-AW Issue Fast Track + Close](https://github.com/arivero/agentbook/actions/runs/21785533800)

<!-- gh-aw-workflow-id: issue-fast-track-close -->