### PR TITLE
docs: clarify intake ACK dispatches routing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ agentbook/
 
 ## 🔧 Automation
 
-This repository uses GitHub Actions and GH-AW workflows for publishing, validation, and issue-processing.
+This repository uses GitHub Actions and GH-AW workflows for publishing, validation, and issue-processing. The intake ACK workflow dispatches the routing workflow via `workflow_dispatch` after acknowledging new issues.
 
 For workflow lifecycle details, see [WORKFLOW_PLAYBOOK.md](WORKFLOW_PLAYBOOK.md).
 For required operator setup (tokens, permissions, and operating checklist), use [content.md](content.md). This is the guide for the required human operator.


### PR DESCRIPTION
Adds a concise sentence to the automation section in README.md explaining that the intake ACK workflow dispatches the routing workflow via `workflow_dispatch` after acknowledging new issues.

This clarifies the sequential flow between the acknowledgment and routing stages of the issue processing pipeline.

`Fixes #110`


> AI generated by [GH-AW Issue Fast Track + Close](https://github.com/arivero/agentbook/actions/runs/21785987619)

<!-- gh-aw-workflow-id: issue-fast-track-close -->