### PR TITLE
Editorial quality improvements: Remove hype language

### DIFF
--- a/book/chapters/055-mcp-skills-directory.md
+++ b/book/chapters/055-mcp-skills-directory.md
@@ -214,7 +214,7 @@ In February 2026, Snyk researchers published the ToxicSkills report after scanni
 
 ## Announcing MCPs and Skills to Visiting Models
 
-As AI agents increasingly browse the web, retrieve documentation, and interact with services, sites need machine-readable ways to advertise their capabilities. This section covers the current state-of-the-art conventions for announcing MCP servers, Agent Skills, and agent policies to visiting models.
+As AI agents increasingly browse the web, retrieve documentation, and interact with services, sites need machine-readable ways to advertise their capabilities. This section covers current conventions for announcing MCP servers, Agent Skills, and agent policies to visiting models.
 
 ### llms.txt: Machine-Readable Site Context
 

--- a/book/chapters/080-agents-for-coding.md
+++ b/book/chapters/080-agents-for-coding.md
@@ -29,7 +29,7 @@ The progression of coding agents follows a clear trajectory through four phases.
 
 ### Current Capabilities
 
-Modern coding agents can perform a range of sophisticated tasks.
+Coding agents today handle multiple development tasks autonomously.
 
 **Understand requirements.** Agents can parse natural language specifications and translate them to code, bridging the gap between human intent and machine-executable instructions.
 


### PR DESCRIPTION
## Summary

This weekly editorial quality pass identified and corrected two instances of unnecessary hype language that violate the project's editorial standards.

## Changes Made

1. **Chapter 055 (MCP Skills Directory)**: Removed "state-of-the-art" hype phrase
   - Before: "current state-of-the-art conventions"
   - After: "current conventions"

2. **Chapter 080 (Agents for Coding)**: Replaced vague marketing language with concrete description
   - Before: "Modern coding agents can perform a range of sophisticated tasks"
   - After: "Coding agents today handle multiple development tasks autonomously"

## Evidence Checked

Verified against editorial standards in:
- `.github/workflows/weekly-editorial-quality.md` (lines 45-58: "Avoid SEO-style language and attention hooks")
- `/AGENTS.md` (line 3: "Do not use SEO tricks")

Both changes improve clarity while preserving technical accuracy. No factual corrections were needed as repository sources (README.md, _config.yml) confirm all publication URLs and dates are correct.

## Scope

These are surgical, high-confidence edits that follow the policy of "high-value editorial edits only" without producing "broad low-value churn." The changes maintain the book's technical tone while eliminating marketing-style language.


> AI generated by [GH-AW Weekly Editorial Quality Pass](https://github.com/arivero/agentbook/actions/runs/23750362078)

<!-- gh-aw-workflow-id: weekly-editorial-quality -->